### PR TITLE
Fix/correct fasta reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ above reference.
 
 The `genomes/fasta_reader.py` can be used to read the `wuhan-hu-1.txt` file 
 by calling its `read_wuhan_1` function with the filepath to `wuhan-hu-1.txt`.
-This function will return 3 strings: `hu1_full_genome, utr5, hu1_gene`. The 
-full genome is just that. `utr5` is the 5'UTR region (first 265 nucleotides),
-and `hu1_gene` is a string comprised of the nuclotides at sites 266-21555. 
+This function will return 2 strings: `hu1_full_genome and hu1_rbd`. The 
+full genome is just that. The `hu1_rbd` is a string comprised of the 
+nucleotides at sites 21563..25384 corresponding (hopefully) to the RBD. 
 It has an arg parser and can be called in the terminal:
 
 ```shell
@@ -27,3 +27,9 @@ you are reading]
 The only option for `-opt` at this stage is `0` for ``read_wuhan_1`. If we 
 use a different FASTA for part 2, we can update the reader to portion it 
 appropriately and add its option. 
+
+### References:
+
+- Length of RBD: Roy, U. Comparative structural analyses of selected spike 
+protein-RBD mutations in SARS-CoV-2 lineages. Immunol Res 70, 143–151 (2022). 
+https://doi.org/10.1007/s12026-021-09250-z

--- a/src/fasta_reader.py
+++ b/src/fasta_reader.py
@@ -15,25 +15,6 @@ def get_genome_string(filepath):
     return "".join(genome)
 
 
-def seperate_genome(genome, start, end):
-    """
-    This function allows you to seperate out specific parts of the genome for
-    analysis.
-    Make sure that your start/end account for the fact that the string is
-    indexed from 0
-    :param genome: a string of the genome
-    :param start: the first nucleotide of the section of the genome you want to
-    analyze
-    (will be included in the result)
-    :param end: the last nucleotide in the section of the genome that you
-    want to analyze (will be included in the result)
-    :return: a string containing a fraction of the genome
-    """
-    # TODO: figure out if I need to do anything else or if it dumb to have a
-    #  one line function omg
-    return genome[start : end + 1]
-
-
 def read_wuhan_1(filepath):
     """
     returns the wuhan-hu-1 genome broken into three parts
@@ -42,10 +23,12 @@ def read_wuhan_1(filepath):
     """
     hu1_full_genome = get_genome_string(filepath).upper()
 
-    utr5 = seperate_genome(hu1_full_genome, 0, 264).upper()
-    hu1_gene = seperate_genome(hu1_full_genome, 265, 21554).upper()
+    # spike protein gene is 21563..25384
+    # RBD may be 22517-23185 start point is 1 less b/c of 0 index, end is same
+    # b/c it is not included
+    hu1_rbd = hu1_full_genome[22516:23185]
 
-    return hu1_full_genome, utr5, hu1_gene
+    return hu1_full_genome, hu1_rbd
 
 
 def build_parser():
@@ -54,7 +37,7 @@ def build_parser():
         "-filepath",
         type=str,
         required=False,
-        default=r"D:\CS523\CAS-523-Proj-2\original\wuhan-hu-1.txt",
+        default=r"D:\CS523\CAS-523-Proj-2\genomes\wuhan-hu-1.txt",
         help="fully qualified filepath to the fasta file you are reading",
     )
     parser.add_argument(
@@ -71,9 +54,8 @@ if __name__ == "__main__":
     options, _ = parser.parse_known_args()
 
     if options.opt == 0:
-        hu1_full_genome, utr5, hu1_gene = read_wuhan_1(options.filepath)
+        hu1_full_genome, hu1_rbd = read_wuhan_1(options.filepath)
         # test confirmed that reading the wuhan-hu-1 file returns the
         # appropriate length strings
         print(len(hu1_full_genome))
-        print(len(utr5))
-        print(len(hu1_gene))
+        print(len(hu1_rbd))


### PR DESCRIPTION
fix: correct fasta reader

- Corrects default value for arg parser directory
- Removes 5'UTR string
- Adds RBD string